### PR TITLE
fix webpack js exclude rule problem in windows

### DIFF
--- a/builder/WeexBuilder.js
+++ b/builder/WeexBuilder.js
@@ -47,7 +47,7 @@ class WeexBuilder extends WebpackBuilder {
     this.config.module.loaders.push({
       test: /\.js(\?[^?]+)?$/,
       loader: this.loadModulePath('babel-loader'),
-      exclude: /node_modules(?!\/.*(weex).*)/
+      exclude: /node_modules(?!(\/|\\).*(weex).*)/
     })
     this.config.module.loaders.push({
       test: /\.we(\?[^?]+)?$/,


### PR DESCRIPTION
fix webpack js exclude rule problem in windows 
ref:[https://github.com/alibaba/weex-ui/issues/50](url)